### PR TITLE
Add Terraform Support for GKE Auto-Monitoring

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -1269,14 +1269,30 @@ func ResourceContainerCluster() *schema.Resource {
 							MaxItems:    1,
 							Description: `Configuration for Google Cloud Managed Services for Prometheus.`,
 							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"enabled": {
-										Type:        schema.TypeBool,
-										Required:    true,
-										Description: `Whether or not the managed collection is enabled.`,
-									},
-								},
-							},
+						        	Schema: map[string]*schema.Schema{
+						            		"enabled": {
+						                		Type:        schema.TypeBool,
+						                		Required:    true,
+						                		Description: `Whether or not the managed collection is enabled.`,
+						            		},
+						            		"auto_monitoring_config": {
+						                		Type:        schema.TypeSet,
+						                		Optional:    true,
+						                		MaxItems:    1,
+						                		Description: `Configuration for GKE Workload Auto-Monitoring.`,
+						                		Elem: &schema.Resource{
+						                    			Schema: map[string]*schema.Schema{
+						                       				"scope": {
+						                            				Type:         schema.TypeString,
+						                            				Required:     true,
+						                            				Description:  `The scope of auto-monitoring.`,
+						                            				ValidateFunc: validation.StringInSlice([]string{"ALL", "NONE"}, false),
+						                        			},
+						                    			},
+						                		},
+						           		},
+						        	},
+						    	},
 						},
 						"advanced_datapath_observability_config": {
 							Type:        schema.TypeList,
@@ -5673,6 +5689,14 @@ func expandMonitoringConfig(configured interface{}) *container.MonitoringConfig 
 		mc.ManagedPrometheusConfig = &container.ManagedPrometheusConfig{
 			Enabled: managed_prometheus["enabled"].(bool),
 		}
+		if autoMonitoring, ok := managed_prometheus["auto_monitoring_config"]; ok && len(autoMonitoring.([]interface{})) > 0 {
+			autoMonitoringConfig := autoMonitoring.([]interface{})[0].(map[string]interface{})
+			if scope, ok := autoMonitoringConfig["scope"].(string); ok {
+				mc.ManagedPrometheusConfig.AutoMonitoringConfig = &container.AutoMonitoringConfig {
+					Scope: scope,
+				}
+			}
+		}
 	}
 
 	if v, ok := config["advanced_datapath_observability_config"]; ok && len(v.([]interface{})) > 0 {
@@ -6585,11 +6609,23 @@ func flattenAdvancedDatapathObservabilityConfig(c *container.AdvancedDatapathObs
 }
 
 func flattenManagedPrometheusConfig(c *container.ManagedPrometheusConfig) []map[string]interface{} {
-	return []map[string]interface{}{
-		{
-			"enabled": c != nil && c.Enabled,
-		},
-	}
+        if c == nil {
+                return nil
+        }
+
+        result := make(map[string]interface{})
+
+        result["enabled"] = c.Enabled
+
+        if c.AutoMonitoringConfig != nil {
+                autoMonitoringMap := make(map[string]interface{})
+                if c.AutoMonitoringConfig.Scope != "" {
+                        autoMonitoringMap["scope"] = c.AutoMonitoringConfig.Scope
+                }
+                result["auto_monitoring_config"] = autoMonitoringMap
+        }
+
+        return []map[string]interface{}{result}
 }
 
 func flattenNodePoolAutoConfig(c *container.NodePoolAutoConfig) []map[string]interface{} {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -9868,7 +9868,10 @@ resource "google_container_cluster" "primary" {
   monitoring_config {
          enable_components = [ "SYSTEM_COMPONENTS", "APISERVER", "CONTROLLER_MANAGER", "SCHEDULER" ]
          managed_prometheus {
-                 enabled = true
+         	enabled = true
+		auto_monitoring_config {
+			scope = "ALL"
+		}
          }
   }
   deletion_protection = false
@@ -9885,9 +9888,12 @@ resource "google_container_cluster" "primary" {
   location           = "us-central1-a"
   initial_node_count = 1
   monitoring_config {
-	     enable_components = []
+  	 enable_components = []
          managed_prometheus {
-                enabled = true
+         	enabled = true
+		auto_monitoring_config {
+			scope = "ALL"
+		}
          }
   }
   deletion_protection = false

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -650,6 +650,7 @@ This block also contains several computed attributes, documented below.
 <a name="nested_managed_prometheus"></a>The `managed_prometheus` block supports:
 
 * `enabled` - (Required) Whether or not the managed collection is enabled.
+* `auto_monitoring_config` - (Optional) Configuration for Auto-Monitoring which includes a `Scope` field (string). Supported values include: `ALL` and `NONE`.
 
 <a name="nested_advanced_datapath_observability_config"></a>The `advanced_datapath_observability_config` block supports:
 


### PR DESCRIPTION
Enable Terraform support for GKE Auto-Monitoring for `google_container_resource`.